### PR TITLE
feal(highlight statuscolumn): add a option toggle highlight statuscolumn

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ vim.cmd[[colorscheme obscure]]
   transparent = false,
   terminal_colors = true,
   dim_inactive = true,
+  hl_statuscolumn_cursorline = false, -- highlight statuscolumn groups (default false)
   styles = {
     keywords = { italic = true },
     identifiers = {},

--- a/doc/obscure.txt
+++ b/doc/obscure.txt
@@ -94,6 +94,7 @@ Default Options ~
       transparent = false,
       terminal_colors = true,
       dim_inactive = true,
+      hl_statuscolumn_cursorline = false, -- highlight statuscolumn groups (default false)
       styles = {
         keywords = { italic = true },
         identifiers = {},

--- a/lua/obscure/config.lua
+++ b/lua/obscure/config.lua
@@ -6,6 +6,7 @@ M.defaults = {
   transparent = false,
   terminal_colors = true,
   dim_inactive = true,
+  hl_statuscolumn_cursorline = false, -- highlight statuscolumn groups (default false)
   styles = {
     keywords = { italic = true },
     identifiers = {},

--- a/lua/obscure/groups/editor.lua
+++ b/lua/obscure/groups/editor.lua
@@ -32,7 +32,9 @@ function M.get(c, opts)
 
     -- Lines
     CursorLine = { bg = c.gray1 }, -- the screen line that the cursor is in when 'cursorline' is set
-    CursorLineNr = { fg = c.subtext1, bold = true }, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
+    CursorLineSign = opts.hl_statuscolumn_cursorline and { bg = c.gray5 } or nil,
+    CursorLineFold = opts.hl_statuscolumn_cursorline and { bg = c.gray5 } or nil,
+    CursorLineNr = opts.hl_statuscolumn_cursorline and { fg = c.subtext1, bg = c.gray5, bold = true } or { fg = c.subtext1, bold = true }, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
     Folded = { fg = c.gray4 }, -- line used for closed folds
     LineNr = { fg = c.gray4 }, -- Line number for " =number" and ":#" commands, and when 'number' or 'relativenumber' option is set.
     LineNrAbove = { fg = c.gray4 },

--- a/lua/obscure/groups/gitsigns.lua
+++ b/lua/obscure/groups/gitsigns.lua
@@ -1,10 +1,18 @@
+local Util = require("obscure.util")
+
 local M = {}
 
-function M.get(c)
+function M.get(c, opts)
   return {
     GitSignsAdd = { fg = c.green },
     GitSignsChange = { fg = c.yellow },
     GitSignsDelete = { fg = c.red },
+    GitSignsAddCul = opts.hl_statuscolumn_cursorline and { bg = c.gray5 } or nil,
+    GitSignsChangeCul = opts.hl_statuscolumn_cursorline and { bg = c.gray5 } or nil,
+    GitSignsChangedeleteCul = opts.hl_statuscolumn_cursorline and { bg = c.gray5 } or nil,
+    GitSignsDeleteCul = opts.hl_statuscolumn_cursorline and { bg = c.gray5 } or nil,
+    GitSignsTopdeleteCul = opts.hl_statuscolumn_cursorline and { bg = c.gray5 } or nil,
+    GitSignsUntrackedCul = opts.hl_statuscolumn_cursorline and { bg = c.gray5 } or nil,
   }
 end
 

--- a/lua/obscure/palettes/obscure.lua
+++ b/lua/obscure/palettes/obscure.lua
@@ -30,6 +30,7 @@ return {
   gray2 = "#2a2a2c",
   gray3 = "#313134",
   gray4 = "#3b3b3e",
+  gray5 = '#002c38', -- statuscolumn color
   -- Special
   none = "NONE",
 }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/45b7ca9e-5d19-45f3-bf00-7b4e12f19c82)
Hi, I want to add highlight to statuscolumn, and I hope it is built-in instead of using on_highlights.
